### PR TITLE
PVA: render survey response as message

### DIFF
--- a/src/app/views/ChatTranscriptVisual.tsx
+++ b/src/app/views/ChatTranscriptVisual.tsx
@@ -38,6 +38,16 @@ export const ChatTranscriptVisual = (props: ChatTranscriptVisualProps): JSX.Elem
     const activityMiddleware = () => next => ({ activity, nextVisibleActivity, ...otherArgs }) => {
         const { name, type } = activity;
 
+        // PVA: Render survey response (submit) as message
+        if (type === ActivityTypes.Message && activity.value) {
+            for (const value in activity.value) {
+                if (["1", "2", "3", "4", "5"].includes(activity.value[value])) {
+                    activity.text = activity.value[value];
+                    return next({ activity, nextVisibleActivity, ...otherArgs });
+                }
+            }
+        }
+
         // Ignore trace activity 
         if (type === ActivityTypes.Trace) {
             return false;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1424596/124172773-85432e00-daaa-11eb-8575-b7f9ebb4ac09.png)

after:
![image](https://user-images.githubusercontent.com/1424596/124172811-8ffdc300-daaa-11eb-9efe-22e2599d08ba.png)
