### PR TITLE
Update API version to 4.7.0 and add privileges

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -1,4 +1,5 @@
 {
+    "privileges": [],
     "supportsLandingPage": true,
     "dataRoles": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "powerbi-botframework-chat-transcripts",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.9",
@@ -17,7 +17,7 @@
         "botframework-webchat": "^4.15.3",
         "core-js": "^3.24.1",
         "moment": "^2.29.4",
-        "powerbi-visuals-api": "^4.7.0",
+        "powerbi-visuals-api": "~4.7.0",
         "powerbi-visuals-utils-dataviewutils": "^2.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "botframework-webchat": "^4.15.3",
     "core-js": "^3.24.1",
     "moment": "^2.29.4",
-    "powerbi-visuals-api": "^4.7.0",
+    "powerbi-visuals-api": "~4.7.0",
     "powerbi-visuals-utils-dataviewutils": "^2.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -9,7 +9,7 @@
     "supportUrl": "https://github.com/iMicknl/powerbi-botframework-chat-transcripts/issues",
     "gitHubUrl": "https://github.com/iMicknl/powerbi-botframework-chat-transcripts"
   },
-  "apiVersion": "4.0.0",
+  "apiVersion": "4.7.0",
   "author": {
     "name": "Mick Vleeshouwer",
     "email": "mivleesh@microsoft.com"


### PR DESCRIPTION
Currently blocked by 'Access External resources' privilege. We provide users the possibility to add a custom URL for an avatar, which will probably be blocked.

We don't want to whitelist all external sites, since this will not be allowed in an enterprise environment.

https://docs.microsoft.com/en-us/power-bi/developer/visuals/capabilities#privileges-define-the-special-permissions-that-your-visual-requires