### PR TITLE
Add support for Rendering Events

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -6,6 +6,7 @@ import powerbi from "powerbi-visuals-api";
 import VisualConstructorOptions = powerbi.extensibility.visual.VisualConstructorOptions;
 import VisualUpdateOptions = powerbi.extensibility.visual.VisualUpdateOptions;
 import IVisual = powerbi.extensibility.visual.IVisual;
+import IVisualEventService = powerbi.extensibility.IVisualEventService;
 
 import VisualObjectInstance = powerbi.VisualObjectInstance;
 import EnumerateVisualObjectInstancesOptions = powerbi.EnumerateVisualObjectInstancesOptions;
@@ -21,11 +22,13 @@ export class Visual implements IVisual {
     
     private constructorOptions: VisualConstructorOptions;
 
+    private events: IVisualEventService;
     private settings: VisualSettings;
 
     constructor(options: VisualConstructorOptions) {
         this.target = options.element;
         this.constructorOptions = options;
+        this.events = options.host.eventService;
         this.renderComponent(React.createElement(App, { constructorOptions: options }));
     }
 
@@ -36,15 +39,17 @@ export class Visual implements IVisual {
     }
 
     public update(options: VisualUpdateOptions) {
+        this.events.renderingStarted(options);
         this.renderComponent(React.createElement(App, { 
             constructorOptions: this.constructorOptions, 
             visualUpdateOptions: options
         }));
+        this.events.renderingFinished(options);
 
         // Persist visual settings
         if (options?.dataViews.length > 0) {
             this.settings = VisualSettings.parse(options.dataViews[0]);
-        }
+        }   
     }
 
     private renderComponent(component) {

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -49,7 +49,7 @@ export class Visual implements IVisual {
         // Persist visual settings
         if (options?.dataViews.length > 0) {
             this.settings = VisualSettings.parse(options.dataViews[0]);
-        }   
+        }
     }
 
     private renderComponent(component) {


### PR DESCRIPTION
This pull request adds functionality to the `Visual` class in the `src/visual.ts` file by introducing an `events` property that allows the class to access the event service provided by the host. This enables the class to notify the event service about the start and end of rendering.

* `src/visual.ts`: Added an `events` property to the `Visual` class, which allows the class to access the event service provided by the host. (F3a86070)

Fix #19